### PR TITLE
Allow for the use of storage units

### DIFF
--- a/src/core/constraint_template.jl
+++ b/src/core/constraint_template.jl
@@ -29,6 +29,13 @@ end
 
 
 ""
+function constraint_storage_active(pm::_PM.AbstractPowerModel, i::Int; nw::Int=nw_id_default)
+    storage = _PM.ref(pm, nw, :storage, i)
+    _PMR.constraint_storage_bus_connection(pm, nw, i, storage["storage_bus"])
+end
+
+
+""
 function constraint_branch_active(pm::_PM.AbstractPowerModel, i::Int; nw::Int=nw_id_default)
     branch = _PM.ref(pm, nw, :branch, i)
 

--- a/src/prob/ops.jl
+++ b/src/prob/ops.jl
@@ -45,8 +45,8 @@ function build_ops(pm::_PM.AbstractPowerModel)
         _PM.constraint_storage_state(pm, i)
         _PM.constraint_storage_complementarity_mi(pm, i)
         _PM.constraint_storage_on_off(pm,i)
-        _PM.constraint_storage_loss(pm, i)
-        _PM.constraint_storage_thermal_limit(pm, i)
+        #_PM.constraint_storage_loss(pm, i)
+        #_PM.constraint_storage_thermal_limit(pm, i)
     end
 
     for i in _PM.ids(pm, :branch)


### PR DESCRIPTION
Defined the function constraint_storage_active to allow for the use of networks with storage units installed. 